### PR TITLE
bump: notify-rust to v4.11.5 to fix compilation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,10 +992,11 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.11.4"
+version = "4.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ae13fb6065b0865d2310dfa55ce319245052ed95fbbe2bc87c99962c58d73f"
+checksum = "7fa3b9f2364a09bd359aa0206702882e208437450866a374d5372d64aece4029"
 dependencies = [
+ "futures-lite",
  "log",
  "mac-notification-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 nu-plugin = "0.102.0"
 
 [dependencies.notify-rust]
-version = "4.11.4"
+version = "4.11.5"
 
 [dependencies.nu-protocol]
 features = ["plugin"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an internal notification component to the latest version to enhance system stability and compatibility. This maintenance upgrade contributes to a smoother overall experience and consistent performance improvements, ensuring reliable operations even though no immediate visual changes occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->